### PR TITLE
Move all Cosmic references into AppState

### DIFF
--- a/components/App.js
+++ b/components/App.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { observer } from 'mobx-react'
 import { FormGroup, FormControl, Input, Button } from 'react-bootstrap'
 import config from '../config'
-import { addObject, deleteObject } from 'cosmicjs'
 import slug from 'slug'
 import S from 'shorti'
 import DevTools from 'mobx-react-devtools';
@@ -18,27 +17,16 @@ export default class App extends Component {
     const content = this.props.data.form_data.content
     if (!title)
       return
-    const object = {
+    const post = {
       slug: slug(title),
       type_slug: 'posts',
       title,
       content
     }
-    this.props.data.is_saving = true
-    addObject({ bucket: config.cosmicjs.bucket }, object, (err, res) => {
-      this.props.data.is_saving = false
-      this.props.data.addPost(res.object)
-      this.props.data.form_data = {
-        title: '',
-        content: ''
-      }
-    })
+    this.props.data.addPost(post);
   }
   handleRemoveClick(post) {
-    this.props.data.removePost(post._id)
-    deleteObject({ bucket: config.cosmicjs.bucket }, { slug: post.slug }, (err, res) => {
-      // object deleted
-    })
+    this.props.data.removePost(post)
   }
   render() {
     const data = this.props.data

--- a/components/AppState.js
+++ b/components/AppState.js
@@ -1,5 +1,5 @@
 import { observable } from 'mobx'
-import { getObjects } from 'cosmicjs'
+import { getObjects, addObject, deleteObject } from 'cosmicjs'
 import config from '../config'
 
 export default class AppState {
@@ -7,12 +7,22 @@ export default class AppState {
   @observable form_data = {}
   @observable is_loading = true
   @observable is_saving = false
-  addPost(post) {
-    this.posts.unshift(post)
+  addPost(object) {
+    this.is_saving = true;
+    addObject({ bucket: config.cosmicjs.bucket }, object, (err, res) => {
+      this.is_saving = false
+      this.posts.unshift(res.object)
+      this.form_data = {
+        title: '',
+        content: ''
+      }
+    })
   }
-  removePost(post_id) {
-    this.posts = this.posts.filter(post => {
-      return post._id !== post_id
+  removePost(post) {
+    deleteObject({ bucket: config.cosmicjs.bucket }, { slug: post.slug }, (err, res) => {
+      this.posts = this.posts.filter(apost => {
+        return apost._id !== post._id
+      })
     })
   }
   constructor() {


### PR DESCRIPTION
As suggested, I have moved all uses of the Cosmic api into the AppState. This, at least, makes it easier to see how to replace Cosmic with another api and it feels right to me to have the store in one place. 

I also _think_ that `@action` decorators should be on the addPost and removePost methods to reduce redraws but I'm not yet experienced enough to be sure. 
